### PR TITLE
BREAKING CHANGE: set inputs default request-review=false and request-revire-header=empty string

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,13 +30,13 @@ inputs:
       Boolean flag. False by default.
       Should send a request review to notify whether the pull request passed or not this verification.
     required: false
-    default: 'true'
+    default: 'false'
   request-review-header:
     description: |
       A string that is attached to the beginning of the review comment.
       Supports GitHub Flavored Markdown.
     required: false
-    default: 'true'
+    default: ''
   github-token:
     description: 'The Github token. Only is required if request-review == true.'
     required: false


### PR DESCRIPTION
Fix default value to two inputs

- request-review=false
- request-revire-header=''
