### PR TITLE
As dev i want to simplify and flexibilize the workflow and use the stable actions to improve it according to user experiences

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
+labels: fix
 assignees: ''
 
 ---

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,7 +8,7 @@ changelog:
         - feature
     - title: 'Fixes :bug:'
       labels:
-        - bug
+        - fix
     - title: Other Changes
       labels:
         - "*"

--- a/.github/workflows/labels-test.yml
+++ b/.github/workflows/labels-test.yml
@@ -7,8 +7,8 @@ on:
       [opened, reopened, synchronize, labeled, unlabeled]
 
 jobs:
-  assign-labels:
-    name: Assign labels from conventional-commits
+  test-labels:
+    name: Assign and test labels from conventional-commits
     if: github.event.pull_request.merged == false
     runs-on: ubuntu-latest
     outputs:
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
 
-      - name: Execute assign labels
+      - name: Assign labels
         id: action-assign-labels
         uses: mauroalderete/action-assign-labels@v1
         with:
@@ -45,17 +45,6 @@ jobs:
               - type: 'config'
                 nouns: ['config', 'conf', 'cofiguration', 'configure']
                 labels: ['config']
-
-  verify-labels:
-    runs-on: ubuntu-latest
-    name: Verify labels
-    needs: assign-labels
-    if: github.event.pull_request.merged == false && (needs.assign-labels.outputs.labels-assigned != '[]' || needs.assign-labels.outputs.labels-removed != '[]')
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          ref: v0
 
       - name: Verify labels
         id: action-verify-labels

--- a/.github/workflows/labels-test.yml
+++ b/.github/workflows/labels-test.yml
@@ -29,7 +29,7 @@ jobs:
             conventional-commits:
               - type: 'fix'
                 nouns: ['FIX', 'Fix', 'fix', 'FIXED', 'Fixed', 'fixed']
-                labels: ['bug']
+                labels: ['fix']
               - type: 'feature'
                 nouns: ['FEATURE', 'Feature', 'feature', 'FEAT', 'Feat', 'feat']
                 labels: ['feature']
@@ -38,20 +38,20 @@ jobs:
                 labels: ['BREAKING CHANGE']
               - type: 'documentation'
                 nouns: ['doc','docu','document','documentation']
-                labels: ['documentation', 'bug']
+                labels: ['documentation', 'fix']
               - type: 'build'
                 nouns: ['build','rebuild']
-                labels: ['build', 'bug']
+                labels: ['build', 'fix']
               - type: 'config'
                 nouns: ['config', 'conf', 'cofiguration', 'configure']
-                labels: ['config', 'bug']
+                labels: ['config', 'fix']
 
       - name: Verify labels
         id: action-verify-labels
         uses: ./
         with:
           none: question, wontfix, invalid
-          some: bug, feature, BREAKING CHANGE, documentation, build, config
+          some: fix, feature, BREAKING CHANGE, documentation, build, config
           request-review: true
           request-review-header: '**:bookmark: verify-labels-action**'
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labels-test.yml
+++ b/.github/workflows/labels-test.yml
@@ -20,19 +20,10 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
 
-      - uses: actions/checkout@v3
-        with:
-          repository: mauroalderete/action-assign-labels
-          ref: v0
-          token: ${{ secrets.WORKFLOWS_TOKEN }}
-          path: ./.github/actions/action-assign-labels
-          persist-credentials: false
-
       - name: Execute assign labels
         id: action-assign-labels
-        uses: ./.github/actions/action-assign-labels
+        uses: mauroalderete/action-assign-labels@v1
         with:
-          pull-request-number: ${{ github.event.pull_request.number }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           conventional-commits: |
             conventional-commits:
@@ -54,8 +45,6 @@ jobs:
               - type: 'config'
                 nouns: ['config', 'conf', 'cofiguration', 'configure']
                 labels: ['config']
-          maintain-labels-not-matched: false
-          apply-changes: true
 
   verify-labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/labels-test.yml
+++ b/.github/workflows/labels-test.yml
@@ -7,7 +7,7 @@ on:
       [opened, reopened, synchronize, labeled, unlabeled]
 
 jobs:
-  test-labels:
+  labels-test:
     name: Assign and test labels from conventional-commits
     if: github.event.pull_request.merged == false
     runs-on: ubuntu-latest
@@ -38,13 +38,13 @@ jobs:
                 labels: ['BREAKING CHANGE']
               - type: 'documentation'
                 nouns: ['doc','docu','document','documentation']
-                labels: ['documentation']
+                labels: ['documentation', 'bug']
               - type: 'build'
                 nouns: ['build','rebuild']
-                labels: ['build']
+                labels: ['build', 'bug']
               - type: 'config'
                 nouns: ['config', 'conf', 'cofiguration', 'configure']
-                labels: ['config']
+                labels: ['config', 'bug']
 
       - name: Verify labels
         id: action-verify-labels


### PR DESCRIPTION
# Description

After using the workflow for this action for many days, I saw some improvements that I achieve implement in this PR:

- Simplify the workflow by using a single job instead of two. This is because on occasion, is needed to run the verification, even if the assignment step doesn't produce any change.
- Use the stable version of the public repository of the action-assign-label.
- Update the job's names and steps to them to be more comprehensible.
- The action-verify-label must be executed with the latest changes proposed by the pull request that triggers the event.
- Rename `bug` by `fix` label name to reduce potential confusion about commits and issues.
- Add `fix` label when a `build`, `conf`, or `doc`type commits is found. This allows guaranteeing a patch bump.

> The `fix` label name is to be interpreted more as adjusting something than as repairing something.

## Type of change

Please delete options that are not relevant.

- [ ] Conf/Fix (non-breaking change which fixes an issue)
